### PR TITLE
Fixed issue #49

### DIFF
--- a/son-sdk-catalogue/routes/catalogue_routes.rb
+++ b/son-sdk-catalogue/routes/catalogue_routes.rb
@@ -80,7 +80,7 @@ class SonataCatalogue < Sinatra::Application
 	# List all NSs in JSON or YAML format
 	get '/network-services' do
 		params[:offset] ||= 1
-		params[:limit] ||= 10
+		params[:limit] ||= 50
 
 		# Only accept positive numbers
 		params[:offset] = 1 if params[:offset].to_i < 1
@@ -782,7 +782,7 @@ class SonataCatalogue < Sinatra::Application
 	# List all VNFs in JSON or YAML format
 	get '/vnfs' do
 		params[:offset] ||= 1
-		params[:limit] ||= 2
+		params[:limit] ||= 50
 
 		# Only accept positive numbers
 		params[:offset] = 1 if params[:offset].to_i < 1


### PR DESCRIPTION
Limit of Descriptors returned has been increased to 50
Now NSD/VNFD APIs have a return limit of 50 Descriptors for a list-all query.
This limit can be increased.
